### PR TITLE
Update DBFlow to 3.1.1 for more accurate results.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,11 +16,13 @@ android {
 
 }
 
+def dbflow_version = "3.1.1"
+
 dependencies {
 
-    apt 'com.raizlabs.android:DBFlow-Compiler:2.1.0'
-    compile "com.raizlabs.android:DBFlow-Core:2.1.0"
-    compile "com.raizlabs.android:DBFlow:2.1.0"
+    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${dbflow_version}"
+    compile "com.github.Raizlabs.DBFlow:dbflow-core:${dbflow_version}"
+    compile "com.github.Raizlabs.DBFlow:dbflow:${dbflow_version}"
 
     // This switches to a local copy of the DBFlow repo
     //apt project(':Libraries:DBFlow:compiler')

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/MainApplication.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/MainApplication.java
@@ -8,6 +8,7 @@ import com.raizlabs.android.databasecomparison.activeandroid.AddressBook;
 import com.raizlabs.android.databasecomparison.activeandroid.AddressItem;
 import com.raizlabs.android.databasecomparison.activeandroid.Contact;
 import com.raizlabs.android.databasecomparison.activeandroid.SimpleAddressItem;
+import com.raizlabs.android.dbflow.config.FlowConfig;
 import com.raizlabs.android.dbflow.config.FlowManager;
 
 import io.realm.Realm;
@@ -38,7 +39,7 @@ public class MainApplication extends SugarApp {
                 .setLogLevel(Ollie.LogLevel.FULL)
                 .init();
 
-        FlowManager.init(this);
+        FlowManager.init(new FlowConfig.Builder(this).build());
 
         Sprinkles.init(this, "sprinkles.db", 2);
 

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
@@ -16,7 +16,8 @@ import java.util.Collection;
  */
 @Table(name = "AddressBook", database = DBFlowDatabase.class,
         cachingEnabled = true,
-        cacheSize = MainActivity.ADDRESS_BOOK_COUNT)
+        cacheSize = MainActivity.ADDRESS_BOOK_COUNT,
+        orderedCursorLookUp = true)
 @ModelContainer
 public class AddressBook extends BaseModel implements IAddressBook<AddressItem, Contact> {
 

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
@@ -1,23 +1,24 @@
 package com.raizlabs.android.databasecomparison.dbflow;
 
-import com.raizlabs.android.databasecomparison.interfaces.IAddressBook;
 import com.raizlabs.android.databasecomparison.MainActivity;
+import com.raizlabs.android.databasecomparison.interfaces.IAddressBook;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ModelContainer;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
-import com.raizlabs.android.dbflow.sql.builder.Condition;
-import com.raizlabs.android.dbflow.sql.language.Select;
-import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import java.util.Collection;
 
 /**
  * Description:
  */
-@Table(tableName = "AddressBook", databaseName = DBFlowDatabase.NAME)
+@Table(name = "AddressBook", database = DBFlowDatabase.class,
+        cachingEnabled = true,
+        cacheSize = MainActivity.ADDRESS_BOOK_COUNT)
 @ModelContainer
-public class AddressBook extends BaseCacheableModel implements IAddressBook<AddressItem, Contact> {
+public class AddressBook extends BaseModel implements IAddressBook<AddressItem, Contact> {
 
     @PrimaryKey(autoincrement = true)
     @Column
@@ -52,14 +53,16 @@ public class AddressBook extends BaseCacheableModel implements IAddressBook<Addr
 
     public Collection<AddressItem> getAddresses() {
         if (addresses == null) {
-            addresses = new Select().from(AddressItem.class).where(Condition.column(AddressItem$Table.ADDRESSBOOK_ADDRESSBOOK).is(id)).queryList();
+            addresses = SQLite.select().from(AddressItem.class)
+                    .where(AddressItem_Table.addressBook.is(id)).queryList();
         }
         return addresses;
     }
 
     public Collection<Contact> getContacts() {
         if (contacts == null) {
-            contacts = new Select().from(Contact.class).where(Condition.column(Contact$Table.ADDRESSBOOK_ADDRESSBOOK).is(id)).queryList();
+            contacts = SQLite.select().from(Contact.class)
+                    .where(Contact_Table.addressBook.is(id)).queryList();
         }
         return contacts;
     }
@@ -77,11 +80,6 @@ public class AddressBook extends BaseCacheableModel implements IAddressBook<Addr
         for (Contact contact : contacts) {
             contact.saveAll();
         }
-    }
-
-    @Override
-    public int getCacheSize() {
-        return MainActivity.ADDRESS_BOOK_COUNT;
     }
 
 }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressBook.java
@@ -4,6 +4,7 @@ import com.raizlabs.android.databasecomparison.MainActivity;
 import com.raizlabs.android.databasecomparison.interfaces.IAddressBook;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.ModelContainer;
+import com.raizlabs.android.dbflow.annotation.OneToMany;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
@@ -15,7 +16,6 @@ import java.util.Collection;
  * Description:
  */
 @Table(name = "AddressBook", database = DBFlowDatabase.class,
-        cachingEnabled = true,
         cacheSize = MainActivity.ADDRESS_BOOK_COUNT,
         orderedCursorLookUp = true)
 @ModelContainer
@@ -52,6 +52,7 @@ public class AddressBook extends BaseModel implements IAddressBook<AddressItem, 
         this.addresses = addresses;
     }
 
+    @OneToMany(methods = OneToMany.Method.ALL)
     public Collection<AddressItem> getAddresses() {
         if (addresses == null) {
             addresses = SQLite.select().from(AddressItem.class)
@@ -60,6 +61,7 @@ public class AddressBook extends BaseModel implements IAddressBook<AddressItem, 
         return addresses;
     }
 
+    @OneToMany(methods = OneToMany.Method.ALL)
     public Collection<Contact> getContacts() {
         if (contacts == null) {
             contacts = SQLite.select().from(Contact.class)

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressItem.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressItem.java
@@ -6,16 +6,14 @@ import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.container.ForeignKeyContainer;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * Description:
  */
-@Table(databaseName = DBFlowDatabase.NAME)
+@Table(database = DBFlowDatabase.class)
 public class AddressItem extends BaseModel implements IAddressItem<AddressBook> {
 
     @PrimaryKey(autoincrement = true)
@@ -36,7 +34,6 @@ public class AddressItem extends BaseModel implements IAddressItem<AddressBook> 
 
     @Column(name = "phone")
     long phone;
-
 
     @Override
     public void setName(String name) {
@@ -69,7 +66,9 @@ public class AddressItem extends BaseModel implements IAddressItem<AddressBook> 
     }
 
     @ForeignKey(
-            references = {@ForeignKeyReference(columnName = "addressBook", columnType = long.class, foreignColumnName = "id")},
+            references = {@ForeignKeyReference(columnName = "addressBook",
+                    columnType = long.class,
+                    foreignKeyColumnName = "id")},
             saveForeignKeyModel = false)
     @Column
     ForeignKeyContainer<AddressBook> addressBook;
@@ -77,9 +76,7 @@ public class AddressItem extends BaseModel implements IAddressItem<AddressBook> 
 
     @Override
     public void setAddressBook(AddressBook addressBook) {
-        this.addressBook = new ForeignKeyContainer<>(AddressBook.class);
-        Map<String, Object> keys = new LinkedHashMap<>();
-        keys.put(AddressBook$Table.ID, addressBook.id);
-        this.addressBook.setData(keys);
+        this.addressBook = FlowManager.getContainerAdapter(AddressBook.class)
+                .toForeignKeyContainer(addressBook);
     }
 }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressItem.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/AddressItem.java
@@ -13,7 +13,7 @@ import com.raizlabs.android.dbflow.structure.container.ForeignKeyContainer;
 /**
  * Description:
  */
-@Table(database = DBFlowDatabase.class)
+@Table(database = DBFlowDatabase.class, orderedCursorLookUp = true)
 public class AddressItem extends BaseModel implements IAddressItem<AddressBook> {
 
     @PrimaryKey(autoincrement = true)

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/Contact.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/Contact.java
@@ -13,7 +13,7 @@ import com.raizlabs.android.dbflow.structure.container.ForeignKeyContainer;
 /**
  * Description:
  */
-@Table(name = "contact", database = DBFlowDatabase.class)
+@Table(name = "contact", database = DBFlowDatabase.class, orderedCursorLookUp = true)
 public class Contact extends BaseModel implements IContact<AddressBook> {
 
     @PrimaryKey(autoincrement = true)

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/Contact.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/Contact.java
@@ -6,20 +6,17 @@ import com.raizlabs.android.dbflow.annotation.ForeignKey;
 import com.raizlabs.android.dbflow.annotation.ForeignKeyReference;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 import com.raizlabs.android.dbflow.structure.container.ForeignKeyContainer;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * Description:
  */
-@Table(tableName = "contact", databaseName = DBFlowDatabase.NAME)
+@Table(name = "contact", database = DBFlowDatabase.class)
 public class Contact extends BaseModel implements IContact<AddressBook> {
 
     @PrimaryKey(autoincrement = true)
-    @Column
     long id;
 
     @Column(name = "name")
@@ -28,10 +25,11 @@ public class Contact extends BaseModel implements IContact<AddressBook> {
     @Column(name = "email")
     String email;
 
-    @ForeignKey(references = {@ForeignKeyReference(columnName = "addressBook",
-                                                   foreignColumnName = "id", columnType = long.class)},
-                saveForeignKeyModel = false)
-    @Column
+    @ForeignKey(references =
+            {@ForeignKeyReference(columnName = "addressBook",
+                    foreignKeyColumnName = "id",
+                    columnType = long.class)},
+            saveForeignKeyModel = false)
     ForeignKeyContainer<AddressBook> addressBook;
 
     @Override
@@ -61,11 +59,8 @@ public class Contact extends BaseModel implements IContact<AddressBook> {
 
     @Override
     public void setAddressBook(AddressBook addressBook) {
-        this.addressBook = new ForeignKeyContainer<>(AddressBook.class);
-        Map<String, Object> keys = new LinkedHashMap<>();
-        keys.put(AddressBook$Table.ID, addressBook.id);
-        this.addressBook.setData(keys);
-        this.addressBook.setModel(addressBook);
+        this.addressBook = FlowManager.getContainerAdapter(AddressBook.class)
+                .toForeignKeyContainer(addressBook);
     }
 
     @Override

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/DBFlowTester.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/DBFlowTester.java
@@ -7,8 +7,12 @@ import com.raizlabs.android.databasecomparison.Loader;
 import com.raizlabs.android.databasecomparison.MainActivity;
 import com.raizlabs.android.databasecomparison.Saver;
 import com.raizlabs.android.databasecomparison.events.LogTestDataEvent;
-import com.raizlabs.android.dbflow.runtime.TransactionManager;
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.language.Delete;
 import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
+import com.raizlabs.android.dbflow.structure.database.transaction.FastStoreModelTransaction;
+import com.raizlabs.android.dbflow.structure.database.transaction.ITransaction;
 
 import java.util.Collection;
 
@@ -21,8 +25,7 @@ public class DBFlowTester {
     public static final String FRAMEWORK_NAME = "DBFlow";
 
     public static void testAddressBooks(Context context) {
-        com.raizlabs.android.dbflow.sql.language.Delete.tables(AddressItem.class,
-                Contact.class, AddressBook.class);
+        Delete.tables(AddressItem.class, Contact.class, AddressBook.class);
 
         Collection<AddressBook> addressBooks = Generator.createAddressBooks(AddressBook.class,
                 Contact.class, AddressItem.class,
@@ -30,12 +33,13 @@ public class DBFlowTester {
 
         long startTime = System.currentTimeMillis();
         final Collection<AddressBook> finalAddressBooks = addressBooks;
-        TransactionManager.transact(DBFlowDatabase.NAME, new Runnable() {
-            @Override
-            public void run() {
-                Saver.saveAll(finalAddressBooks);
-            }
-        });
+        FlowManager.getDatabase(DBFlowDatabase.class)
+                .executeTransaction(new ITransaction() {
+                    @Override
+                    public void execute(DatabaseWrapper databaseWrapper) {
+                        Saver.saveAll(finalAddressBooks);
+                    }
+                });
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
         startTime = System.currentTimeMillis();
@@ -44,28 +48,27 @@ public class DBFlowTester {
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
 
 
-        com.raizlabs.android.dbflow.sql.language.Delete.tables(AddressItem.class,
-                                                               Contact.class, AddressBook.class);
+        Delete.tables(AddressItem.class,
+                Contact.class, AddressBook.class);
     }
 
     public static void testAddressItems(Context context) {
-        com.raizlabs.android.dbflow.sql.language.Delete.table(SimpleAddressItem.class);
+        Delete.table(SimpleAddressItem.class);
         Collection<SimpleAddressItem> dbFlowModels =
                 Generator.getAddresses(SimpleAddressItem.class, MainActivity.LOOP_COUNT);
         long startTime = System.currentTimeMillis();
         final Collection<SimpleAddressItem> finalDbFlowModels = dbFlowModels;
-        TransactionManager.transact(DBFlowDatabase.NAME, new Runnable() {
-            @Override
-            public void run() {
-                Saver.saveAll(finalDbFlowModels);
-            }
-        });
+        FlowManager.getDatabase(DBFlowDatabase.class)
+                .executeTransaction(FastStoreModelTransaction
+                        .insertBuilder(FlowManager.getModelAdapter(SimpleAddressItem.class))
+                        .addAll(finalDbFlowModels)
+                        .build());
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
         startTime = System.currentTimeMillis();
         dbFlowModels = new Select().from(SimpleAddressItem.class).queryList();
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
 
-        com.raizlabs.android.dbflow.sql.language.Delete.table(SimpleAddressItem.class);
+        Delete.table(SimpleAddressItem.class);
     }
 }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/DBFlowTester.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/DBFlowTester.java
@@ -3,12 +3,11 @@ package com.raizlabs.android.databasecomparison.dbflow;
 import android.content.Context;
 
 import com.raizlabs.android.databasecomparison.Generator;
-import com.raizlabs.android.databasecomparison.Loader;
 import com.raizlabs.android.databasecomparison.MainActivity;
-import com.raizlabs.android.databasecomparison.Saver;
 import com.raizlabs.android.databasecomparison.events.LogTestDataEvent;
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Delete;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.structure.database.DatabaseWrapper;
 import com.raizlabs.android.dbflow.structure.database.transaction.FastStoreModelTransaction;
@@ -37,14 +36,16 @@ public class DBFlowTester {
                 .executeTransaction(new ITransaction() {
                     @Override
                     public void execute(DatabaseWrapper databaseWrapper) {
-                        Saver.saveAll(finalAddressBooks);
+                        for (AddressBook addressBook : finalAddressBooks) {
+                            addressBook.insert();
+                        }
                     }
                 });
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
         startTime = System.currentTimeMillis();
-        addressBooks = new Select().from(AddressBook.class).queryList();
-        Loader.loadAllInnerData(addressBooks);
+        addressBooks = SQLite.select().from(AddressBook.class).queryList();
+
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
 
 

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/SimpleAddressItem.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/SimpleAddressItem.java
@@ -12,7 +12,8 @@ import com.raizlabs.android.dbflow.structure.BaseModel;
  */
 @Table(database = DBFlowDatabase.class,
         cachingEnabled = true,
-        cacheSize = MainActivity.LOOP_COUNT)
+        cacheSize = MainActivity.LOOP_COUNT,
+        orderedCursorLookUp = true)
 public class SimpleAddressItem extends BaseModel implements IAddressItem<AddressBook> {
 
     @PrimaryKey(autoincrement = true)

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/SimpleAddressItem.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/dbflow/SimpleAddressItem.java
@@ -1,20 +1,21 @@
 package com.raizlabs.android.databasecomparison.dbflow;
 
-import com.raizlabs.android.databasecomparison.interfaces.IAddressItem;
 import com.raizlabs.android.databasecomparison.MainActivity;
+import com.raizlabs.android.databasecomparison.interfaces.IAddressItem;
 import com.raizlabs.android.dbflow.annotation.Column;
 import com.raizlabs.android.dbflow.annotation.PrimaryKey;
 import com.raizlabs.android.dbflow.annotation.Table;
-import com.raizlabs.android.dbflow.structure.cache.BaseCacheableModel;
+import com.raizlabs.android.dbflow.structure.BaseModel;
 
 /**
  * Description:
  */
-@Table(databaseName = DBFlowDatabase.NAME)
-public class SimpleAddressItem extends BaseCacheableModel implements IAddressItem<AddressBook> {
+@Table(database = DBFlowDatabase.class,
+        cachingEnabled = true,
+        cacheSize = MainActivity.LOOP_COUNT)
+public class SimpleAddressItem extends BaseModel implements IAddressItem<AddressBook> {
 
     @PrimaryKey(autoincrement = true)
-    @Column
     long id;
 
     @Column(name = "name")
@@ -67,8 +68,4 @@ public class SimpleAddressItem extends BaseCacheableModel implements IAddressIte
         super.insert();
     }
 
-    @Override
-    public int getCacheSize() {
-        return MainActivity.LOOP_COUNT;
-    }
 }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/ollie/OllieTester.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/ollie/OllieTester.java
@@ -1,13 +1,13 @@
 package com.raizlabs.android.databasecomparison.ollie;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
 
 import com.raizlabs.android.databasecomparison.Generator;
 import com.raizlabs.android.databasecomparison.Loader;
 import com.raizlabs.android.databasecomparison.MainActivity;
 import com.raizlabs.android.databasecomparison.Saver;
 import com.raizlabs.android.databasecomparison.events.LogTestDataEvent;
-import com.raizlabs.android.dbflow.runtime.TransactionManager;
 
 import java.util.Collection;
 
@@ -19,60 +19,60 @@ import ollie.query.Select;
 /**
  * Created by Tjones on 8/16/15.
  */
-public class OllieTester
-{
-	public static final String FRAMEWORK_NAME = "Ollie";
+public class OllieTester {
+    public static final String FRAMEWORK_NAME = "Ollie";
 
-	public static void testAddressBooks(Context context) {
-		Delete.from(AddressItem.class).execute();
-		Delete.from(Contact.class).execute();
-		Delete.from(AddressBook.class).execute();
+    public static void testAddressBooks(Context context) {
+        Delete.from(AddressItem.class).execute();
+        Delete.from(Contact.class).execute();
+        Delete.from(AddressBook.class).execute();
 
-		Collection<AddressBook> addressBooks = Generator.createAddressBooks(AddressBook.class, Contact.class, AddressItem.class, MainActivity.ADDRESS_BOOK_COUNT);
+        Collection<AddressBook> addressBooks = Generator.createAddressBooks(AddressBook.class, Contact.class, AddressItem.class, MainActivity.ADDRESS_BOOK_COUNT);
 
-		long startTime = System.currentTimeMillis();
-		final Collection<AddressBook> finalAddressBooks = addressBooks;
-		TransactionManager.transact(Ollie.getDatabase(), new Runnable()
-		{
-			@Override
-			public void run()
-			{
-				Saver.saveAll(finalAddressBooks);
-			}
-		});
-		EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
+        long startTime = System.currentTimeMillis();
+        final Collection<AddressBook> finalAddressBooks = addressBooks;
+        SQLiteDatabase database = Ollie.getDatabase();
+        database.beginTransaction();
+        try {
+            Saver.saveAll(finalAddressBooks);
+            database.setTransactionSuccessful();
+        } finally {
+            database.endTransaction();
+        }
+        EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
-		startTime = System.currentTimeMillis();
-		addressBooks = Select.from(AddressBook.class).fetch();
-		Loader.loadAllInnerData(addressBooks);
-		EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
+        startTime = System.currentTimeMillis();
+        addressBooks = Select.from(AddressBook.class).fetch();
+        Loader.loadAllInnerData(addressBooks);
+        EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
 
-		Delete.from(AddressItem.class).execute();
-		Delete.from(Contact.class).execute();
-		Delete.from(AddressBook.class).execute();
-	}
+        Delete.from(AddressItem.class).execute();
+        Delete.from(Contact.class).execute();
+        Delete.from(AddressBook.class).execute();
+    }
 
-	public static void testAddressItems(Context context) {
-		Delete.from(SimpleAddressItem.class).execute();
+    public static void testAddressItems(Context context) {
+        Delete.from(SimpleAddressItem.class).execute();
 
-		final Collection<SimpleAddressItem> ollieModels =
-				Generator.getAddresses(SimpleAddressItem.class, MainActivity.LOOP_COUNT);
+        final Collection<SimpleAddressItem> ollieModels =
+                Generator.getAddresses(SimpleAddressItem.class, MainActivity.LOOP_COUNT);
 
-		long startTime = System.currentTimeMillis();
-		// Reuse method so we don't have to write
-		TransactionManager.transact(Ollie.getDatabase(), new Runnable() {
-			@Override
-			public void run() {
-				Saver.saveAll(ollieModels);
-			}
-		});
-		EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
+        long startTime = System.currentTimeMillis();
+        SQLiteDatabase database = Ollie.getDatabase();
+        database.beginTransaction();
+        try {
+            Saver.saveAll(ollieModels);
+            database.setTransactionSuccessful();
+        } finally {
+            database.endTransaction();
+        }
+        EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
-		startTime = System.currentTimeMillis();
-		Collection<SimpleAddressItem> activeAndroidModelLoad =
-				Select.from(SimpleAddressItem.class).fetch();
-		EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
+        startTime = System.currentTimeMillis();
+        Collection<SimpleAddressItem> activeAndroidModelLoad =
+                Select.from(SimpleAddressItem.class).fetch();
+        EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.LOAD_TIME));
 
-		Delete.from(SimpleAddressItem.class).execute();
-	}
+        Delete.from(SimpleAddressItem.class).execute();
+    }
 }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/sugar/SugarTester.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/sugar/SugarTester.java
@@ -1,6 +1,7 @@
 package com.raizlabs.android.databasecomparison.sugar;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
 
 import com.raizlabs.android.databasecomparison.Generator;
 import com.raizlabs.android.databasecomparison.Loader;
@@ -8,7 +9,6 @@ import com.raizlabs.android.databasecomparison.MainActivity;
 import com.raizlabs.android.databasecomparison.MainApplication;
 import com.raizlabs.android.databasecomparison.Saver;
 import com.raizlabs.android.databasecomparison.events.LogTestDataEvent;
-import com.raizlabs.android.dbflow.runtime.TransactionManager;
 
 import java.util.Collection;
 
@@ -29,12 +29,15 @@ public class SugarTester {
                 Contact.class, AddressItem.class, MainActivity.ADDRESS_BOOK_COUNT);
         long startTime = System.currentTimeMillis();
         final Collection<AddressBook> finalAddressBooks = addressBooks;
-        TransactionManager.transact(MainApplication.getSugarDatabase().getDB(), new Runnable() {
-            @Override
-            public void run() {
-                Saver.saveAll(finalAddressBooks);
-            }
-        });
+
+        SQLiteDatabase database = MainApplication.getSugarDatabase().getDB();
+        database.beginTransaction();
+        try {
+            Saver.saveAll(finalAddressBooks);
+            database.setTransactionSuccessful();
+        } finally {
+            database.endTransaction();
+        }
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
         startTime = System.currentTimeMillis();


### PR DESCRIPTION
Update's DBFlow to 3.1.1. Uses the new `FastStoreModelTransaction` on the simple address items, which is the fastest way to store data in DBFlow.

Also set `orderedCursorLookup` in each table so that loading from `Cursor` is on same level as greenDAO

Dont cache `AddressBook` items in complex load for DBFlow. 
