### PR TITLE
Update Realm code

### DIFF
--- a/app/src/main/java/com/raizlabs/android/databasecomparison/MainApplication.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/MainApplication.java
@@ -42,8 +42,7 @@ public class MainApplication extends SugarApp {
 
         Sprinkles.init(this, "sprinkles.db", 2);
 
-        RealmConfiguration realmConfig = new RealmConfiguration.Builder(this).build();
-        Realm.setDefaultConfiguration(realmConfig);
+        Realm.init(this);
 
         mDatabase = getDatabase();
     }

--- a/app/src/main/java/com/raizlabs/android/databasecomparison/realm/RealmTester.java
+++ b/app/src/main/java/com/raizlabs/android/databasecomparison/realm/RealmTester.java
@@ -31,11 +31,7 @@ public class RealmTester {
         long startTime = System.currentTimeMillis();
         final Collection<AddressBook> finalAddressBooks = addressBooks;
         realm.beginTransaction();
-        for (AddressBook book : finalAddressBooks) {
-            realm.copyToRealmOrUpdate(book.contacts);
-            realm.copyToRealmOrUpdate(book.addresses);
-        }
-        realm.copyToRealmOrUpdate(finalAddressBooks);
+        realm.insertOrUpdate(finalAddressBooks);
         realm.commitTransaction();
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 
@@ -62,7 +58,7 @@ public class RealmTester {
         Collection<SimpleAddressItem> modelList = Generator.getAddresses(SimpleAddressItem.class, MainActivity.LOOP_COUNT);
         long startTime = System.currentTimeMillis();
         realm.beginTransaction();
-        realm.copyToRealm(modelList);
+        realm.insertOrUpdate(modelList);
         realm.commitTransaction();
         EventBus.getDefault().post(new LogTestDataEvent(startTime, FRAMEWORK_NAME, MainActivity.SAVE_TIME));
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
 
-        classpath "io.realm:realm-gradle-plugin:1.1.0"
+        classpath "io.realm:realm-gradle-plugin:2.1.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
1. It doesn't make sense to iterate through all address books to call insert methods for contacts and address items as when you call `realm.insertOrUpdate(finalAddressBooks)`, all contacts and addresses referenced are also inserted. This is similar to DBFlowTester calling only `Saver.saveAll(finalAddressBooks)`, without needing to call this same method for contacts and address items.

2. Call `insertOrUpdate()` instead of `copyToRealm()`, as we are concerned only about inserting these entities, and not retrieving the newly inserted items. `insertOrUpdate()` doesn't return the inserted entites, and as stated in the [docs](https://realm.io/docs/java/latest/api/), this makes it run faster.

3. Update Realm version. 